### PR TITLE
Se borraron los comentarios de application.properties por causar errores

### DIFF
--- a/TP2_Grupo12/src/main/resources/application.properties
+++ b/TP2_Grupo12/src/main/resources/application.properties
@@ -1,24 +1,18 @@
 server.port=8089
-#Datos de conexiÃ³n con la base de datos Mysql
+
 spring.datasource.url = jdbc:mysql://localhost:3306/tp7grupo12?serverTimezone=UTC
-#agregar nombre cambiar libro_autor
+
 spring.datasource.username = root
 spring.datasource.password = root
 
-#habilita el registro de declaraciones SQL
+
 spring.jpa.show-sql = true
-#definicion de mysql dialect
+
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
-#iniciar el esquema
+
 spring.jpa.generate-ddl = true
-#configuracion para el acceso a la base de datos
+
 spring.jpa.hibernate.ddl-auto =create-drop
-#esto borra si uso el update ya pasa a ocupar el valor update 
 
-#spring.jpa.hibernate.ddl-auto =update
-
-
-#Al establecer esta propiedad en false, se deshabilita la ejecución de consultas durante
-#la renderización de vistas y se eliminará la advertencia.
 spring.jpa.open-in-view=false
 


### PR DESCRIPTION
Se quitaron los comentarios de application.properties por que no dejaba reconocer la base de datos.
Texto del application.properties con los comentarios borrados:

server.port=8089
#Datos de conexiÃ³n con la base de datos Mysql
spring.datasource.url = jdbc:mysql://localhost:3306/tp7grupo12?serverTimezone=UTC
#agregar nombre cambiar libro_autor
spring.datasource.username = root
spring.datasource.password = root

#habilita el registro de declaraciones SQL
spring.jpa.show-sql = true
#definicion de mysql dialect
spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
#iniciar el esquema
spring.jpa.generate-ddl = true
#configuracion para el acceso a la base de datos
spring.jpa.hibernate.ddl-auto =create-drop
#esto borra si uso el update ya pasa a ocupar el valor update 

#spring.jpa.hibernate.ddl-auto =update


#Al establecer esta propiedad en false, se deshabilita la ejecución de consultas durante
#la renderización de vistas y se eliminará la advertencia.
spring.jpa.open-in-view=false
